### PR TITLE
Disable default libc features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ readme = "README.md"
 name = "libc_print"
 
 [dependencies]
-libc = "0.2.62"
+libc = { version = "0.2.62", default-features = false }


### PR DESCRIPTION
This prevents it from linking to `std`.

See #1.