### PR TITLE
(hotfix for #12) Fix error when importing macros via std_name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@ pub fn __libc_println(handle: i32, msg: &str) -> core::fmt::Result {
 /// `println!` macro instead of this longer name.
 #[macro_export]
 macro_rules! libc_println {
-    () => { libc_println!("") };
+    () => { $crate::libc_println!("") };
     ($($arg:tt)*) => {
         #[allow(unused_must_use)]
         {
@@ -143,7 +143,7 @@ macro_rules! libc_print {
 /// `eprintln!` macro instead of this longer name.
 #[macro_export]
 macro_rules! libc_eprintln {
-    () => { libc_eprintln!("") };
+    () => { $crate::libc_eprintln!("") };
     ($($arg:tt)*) => {
         #[allow(unused_must_use)]
         {


### PR DESCRIPTION
Wow, you were really quick to merge #12, thanks!

Unfortunately, I immediately found a bug in the PR that breaks the macros when they are imported via the `std_name` module.

This hotfix should do the trick :)