### PR TITLE
Ensure that all bytes are written to the fd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "ad5c14e80759d0939d013e6ca49930e59fc53dd8e5009132f76240c179380c09"
 
 [[package]]
 name = "libc-print"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "libc",
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,9 +73,9 @@ pub fn __libc_println(handle: i32, msg: &str) -> core::fmt::Result {
     let mut written = 0;
     while written < msg.len() {
         match unsafe { libc_write(handle, &msg[written..]) } {
-            Some(res) => written += res,
             // Ignore errors
-            None => break,
+            None | Some(0) => break,
+            Some(res) => written += res,
         }
     }
 


### PR DESCRIPTION
The current implementation has a bug that if the buffer is only partially written, it won't attempt to retry the option with the remaining bytes of the buffer. This PR fixes that by calling `write` in a loop. Also, I implemented some slightly more correct behaviour around integer limits by making use of `try_from`.