### PR TITLE
feat #17: add dbg macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "libc"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libc-print"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ readme = "README.md"
 name = "libc_print"
 
 [dependencies]
-libc = { version = "0.2.120", default-features = false }
+libc = { version = "0.2.126", default-features = false }

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ module.
 
 Exactly as you'd use `println!`, `eprintln!` and `dbg!`.
 
-```
+```rust
 #![no_std]
 
 // ...

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# no_std libc print/println/eprint/eprintln
+# no_std libc print/println/eprint/eprintln/dbg
 
 [![Build Status](https://api.travis-ci.org/mmastrac/rust-libc-print.svg?branch=master)](https://travis-ci.org/mmastrac/rust-libc-print)
 [![docs.rs](https://docs.rs/libc-print/badge.svg)](https://docs.rs/libc-print)
@@ -17,13 +17,28 @@ module.
 
 ## Usage
 
-Exactly as you'd use `println!` or `eprintln!`.
+Exactly as you'd use `println!`, `eprintln!` and `dbg!`.
 
 ```
 #![no_std]
 
 // ...
 
-libc_println!("Hello {}!", "world");
-```
+// Use the default `libc_`-prefixed macros:
 
+libc_println!("Hello {}!", "stdout");
+libc_eprintln!("Hello {}!", "stderr");
+let a = 2;
+let b = libc_dbg!(a * 2) + 1;
+assert_eq!(b, 5);
+
+// Or you can:
+
+use libc_print::std_name;
+
+println!("Hello {}!", "stdout");
+eprintln!("Hello {}!", "stderr");
+let a = 2;
+let b = dbg!(a * 2) + 1;
+assert_eq!(b, 5);
+```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![docs.rs](https://docs.rs/libc-print/badge.svg)](https://docs.rs/libc-print)
 [![crates.io](https://img.shields.io/crates/v/libc-print.svg)](https://crates.io/crates/libc-print)
 
-Implements `println!` and `eprintln!` on the `libc` crate without 
+Implements `println!`, `eprintln!` and `dbg!` on the `libc` crate without 
 requiring the use of an allocator.
 
 Allows you to use these macros in a `#![no_std]` context, or in a 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! Implements `println!` and `eprintln!` on top of the `libc `crate without requiring
+//! Implements `println!`, `eprintln!` and `dbg!` on top of the `libc `crate without requiring
 //! the use of an allocator.
 //!
 //! Allows you to use these macros in a #!\[no_std\] context, or in a situation where the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,32 @@
 //!
 //! ## Usage
 //!
-//! Exactly as you'd use `println!` or `eprintln!`.
+//! Exactly as you'd use `println!`, `eprintln!` and `dbg!`.
+//!
+//! ```
+//! #![no_std]
+//!
+//! // ...
+//!
+//! // Use the default `libc_`-prefixed macros:
+//!
+//! libc_println!("Hello {}!", "stdout");
+//! libc_eprintln!("Hello {}!", "stderr");
+//! let a = 2;
+//! let b = libc_dbg!(a * 2) + 1;
+//! assert_eq!(b, 5);
+//!
+//! // Or you can:
+//!
+//! use libc_print::std_name;
+//!
+//! println!("Hello {}!", "stdout");
+//! eprintln!("Hello {}!", "stderr");
+//! let a = 2;
+//! let b = dbg!(a * 2) + 1;
+//! assert_eq!(b, 5);
+//! ```
+
 
 #![no_std]
 #![allow(dead_code)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! Exactly as you'd use `println!`, `eprintln!` and `dbg!`.
 //!
-//! ```
+//! ```rust
 //! #![no_std]
 //!
 //! // ...

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! Implements `println!` and `eprintln!` on top of the `libc `crate without requiring
 //! the use of an allocator.
 //!
-//! Allows you to use these macros in a #![no_std] context, or in a situation where the
+//! Allows you to use these macros in a #!\[no_std\] context, or in a situation where the
 //! traditional Rust streams might not be available (ie: at process shutdown time).
 //!
 //! [`libc_writeln`] and [`libc_ewriteln`] are provided for cases where you may not wish
@@ -13,13 +13,14 @@
 
 #![no_std]
 #![allow(dead_code)]
+#![allow(unused)]
 #![warn(unsafe_op_in_unsafe_fn)]
 
-use core::convert::TryFrom;
+use core::{convert::TryFrom, file, line, stringify};
 
 /// This forces a "C" library linkage
 #[cfg(not(windows))]
-#[link(name="c")]
+#[link(name = "c")]
 mod c {
     extern "C" {}
 }
@@ -201,7 +202,7 @@ macro_rules! libc_write {
             let mut stm = $crate::__LibCWriter::new($crate::__LIBC_STDOUT);
             stm.write_str($arg);
         }
-    }
+    };
 }
 
 /// Macro for printing a static string to the standard error.
@@ -215,7 +216,7 @@ macro_rules! libc_ewrite {
             let mut stm = $crate::__LibCWriter::new($crate::__LIBC_STDERR);
             stm.write_str($arg);
         }
-    }
+    };
 }
 
 /// Macro for printing a static string to the standard output, with a newline.
@@ -230,7 +231,7 @@ macro_rules! libc_writeln {
             stm.write_str($arg);
             stm.write_nl();
         }
-    }
+    };
 }
 
 /// Macro for printing a static string to the standard error, with a newline.
@@ -245,20 +246,55 @@ macro_rules! libc_ewriteln {
             stm.write_str($arg);
             stm.write_nl();
         }
-    }
+    };
+}
+
+/// Prints and returns the value of a given expression for quick and dirty
+/// debugging.
+///
+/// An example:
+///
+/// ```rust
+/// let a = 2;
+/// let b = dbg!(a * 2) + 1;
+/// //      ^-- prints: [src/main.rs:2] a * 2 = 4
+/// assert_eq!(b, 5);
+/// ```
+///
+/// See [dbg!](https://doc.rust-lang.org/std/macro.dbg.html) for full documentation.
+///
+/// You may wish to `use libc_print::std_name::*` to use a replacement
+/// `dbg!` macro instead of this longer name.
+#[macro_export]
+macro_rules! libc_dbg {
+    () => {
+        $crate::libc_eprintln!("[{}:{}]", $file!(), $line!())
+    };
+    ($val:expr $(,)?) => {
+        match $val {
+            tmp => {
+                $crate::libc_eprintln!("[{}:{}] {} = {:#?}", file!(), line!(), stringify!($val), &tmp);
+                tmp
+            }
+        }
+    };
+    ($($val:expr),+ $(,)?) => {
+        ($($crate::libc_dbg!($val)),+,)
+    };
 }
 
 /// This package contains the `libc_print` macros, but using the stdlib names
 /// such as `println!`, `print!`, etc.
 pub mod std_name {
-    pub use super::libc_print as print;
-    pub use super::libc_println as println;
+    pub use super::libc_dbg as dbg;
     pub use super::libc_eprint as eprint;
     pub use super::libc_eprintln as eprintln;
+    pub use super::libc_print as print;
+    pub use super::libc_println as println;
 
     #[cfg(test)]
     mod tests_std_name {
-        use super::{println, eprintln};
+        use super::{eprintln, println};
 
         #[test]
         fn test_stdout() {
@@ -292,5 +328,12 @@ mod tests {
     #[test]
     fn test_stderr_write() {
         super::libc_ewriteln!("stderr!");
+    }
+
+    #[test]
+    fn test_dbg() {
+        let a = 2;
+        let b = libc_dbg!(a * 2) + 1;
+        assert_eq!(b, 5);
     }
 }


### PR DESCRIPTION
#### changes:
1. add `dbg!` macro. Closes #17 
2. update `libc` version from `0.2.120` to `0.2.126` so that we can directly close #69 instead of merging it.

#### Something I am not sure:
Before I made this PR, if I build this crate, the compiler gives the following error:

```shell
warning: attribute should be applied to an `extern` block
  --> src/lib.rs:24:1
   |
24 |   #[link(name = "c")]
   |   ^^^^^^^^^^^^^^^^^^^
25 | / mod c {
26 | |     extern "C" {}
27 | | }
   | |_- not an `extern` block
   |
   = note: `#[warn(unused_attributes)]` on by default
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
```
And my PR relies on `core::{file, line, stringify}`, to silence the unused warning of these macros, I added `#![allow(unused)]`
```shell
warning: unused imports: `file`, `line`, `stringify`
  --> src/lib.rs:20:12
   |
20 | use core::{file, line, stringify};
   |            ^^^^  ^^^^  ^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default
```
And after I added this attribute, the first warning is also killed. I am not sure if this is fine:(