### PR TITLE
Support os=none/unknown wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libc-print"
-version = "0.1.23"
+version = "0.2.0"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "libc-print"
-version = "0.1.23"
+version = "0.2.0"
 authors = ["Matt Mastracci <matthew@mastracci.com>"]
-edition = "2018"
+edition = "2021"
 description = "println! and eprintln! macros on libc without stdlib"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/mmastrac/rust-libc-print"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ By default this crate provides `libc_`-prefixed macros, but also allows consumer
 import macros with the same name as the stdlib printing macros via the `std_name`
 module.
 
+## Platform Support
+
+For platforms with `write` in libc, this crate uses `libc::write`. For `unknown`
+and `none` OS targets, the user is required to provide a `write` function via
+the linker.
+
 ## Usage
 
 Exactly as you'd use `println!`, `eprintln!` and `dbg!`.

--- a/examples/writeln.rs
+++ b/examples/writeln.rs
@@ -5,7 +5,9 @@ use libc_print::*;
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
     libc_println!("Hello, {}!", "world");
-    unsafe { libc::exit(0); }
+    unsafe {
+        libc::exit(0);
+    }
 }
 
 #[cfg(not(nostartfiles))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,28 +104,22 @@ pub fn __libc_println(handle: i32, msg: &str) -> core::fmt::Result {
     Ok(())
 }
 
-#[cfg(not(windows))]
-unsafe fn libc_write(handle: i32, bytes: &[u8]) -> Option<usize> {
-    usize::try_from(unsafe {
-        libc::write(
-            handle,
-            bytes.as_ptr().cast::<core::ffi::c_void>(),
-            bytes.len(),
-        )
-    })
-    .ok()
+#[cfg(any(all(target_family = "wasm", target_os = "unknown"), target_os = "none"))]
+mod write {
+    pub(crate) use libc::write;
 }
 
-#[cfg(windows)]
+#[cfg(not(any(all(target_family = "wasm", target_os = "unknown"), target_os = "none")))]
+mod write {
+    // The user is required to provide this
+    unsafe extern "C" {
+        pub(crate) fn write(fd: i32, buf: *const u8, nbyte: usize) -> isize;
+    }
+}
+
 unsafe fn libc_write(handle: i32, bytes: &[u8]) -> Option<usize> {
-    usize::try_from(unsafe {
-        libc::write(
-            handle,
-            bytes.as_ptr().cast::<core::ffi::c_void>(),
-            libc::c_uint::try_from(bytes.len()).unwrap_or(libc::c_uint::MAX),
-        )
-    })
-    .ok()
+    usize::try_from(unsafe { write::write(handle as _, bytes.as_ptr() as _, bytes.len() as _) })
+        .ok()
 }
 
 /// Macro for printing to the standard output, with a newline.
@@ -239,15 +233,13 @@ macro_rules! libc_write {
 /// Does not panic on failure to write - instead silently ignores errors.
 #[macro_export]
 macro_rules! libc_ewrite {
-    ($arg:expr) => {
+    ($arg:expr) => {{
+        #[allow(unused_must_use)]
         {
-            #[allow(unused_must_use)]
-            {
-                let mut stm = $crate::__LibCWriter::new($crate::__LIBC_STDERR);
-                stm.write_str($arg);
-            }
+            let mut stm = $crate::__LibCWriter::new($crate::__LIBC_STDERR);
+            stm.write_str($arg);
         }
-    };
+    }};
 }
 
 /// Macro for printing a static string to the standard output, with a newline.
@@ -270,16 +262,14 @@ macro_rules! libc_writeln {
 /// Does not panic on failure to write - instead silently ignores errors.
 #[macro_export]
 macro_rules! libc_ewriteln {
-    ($arg:expr) => {
+    ($arg:expr) => {{
+        #[allow(unused_must_use)]
         {
-            #[allow(unused_must_use)]
-            {
-                let mut stm = $crate::__LibCWriter::new($crate::__LIBC_STDERR);
-                stm.write_str($arg);
-                stm.write_nl();
-            }
+            let mut stm = $crate::__LibCWriter::new($crate::__LIBC_STDERR);
+            stm.write_str($arg);
+            stm.write_nl();
         }
-    };
+    }};
 }
 
 /// Prints and returns the value of a given expression for quick and dirty

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,12 +104,12 @@ pub fn __libc_println(handle: i32, msg: &str) -> core::fmt::Result {
     Ok(())
 }
 
-#[cfg(any(all(target_family = "wasm", target_os = "unknown"), target_os = "none"))]
+#[cfg(not(any(all(target_family = "wasm", target_os = "unknown"), target_os = "none")))]
 mod write {
     pub(crate) use libc::write;
 }
 
-#[cfg(not(any(all(target_family = "wasm", target_os = "unknown"), target_os = "none")))]
+#[cfg(any(all(target_family = "wasm", target_os = "unknown"), target_os = "none"))]
 mod write {
     // The user is required to provide this
     unsafe extern "C" {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,11 +40,9 @@
 //! ```
 
 #![no_std]
-#![allow(dead_code)]
-#![allow(unused)]
 #![warn(unsafe_op_in_unsafe_fn)]
 
-use core::{convert::TryFrom, file, line, stringify};
+use core::convert::TryFrom;
 
 // These constants are used by the macros but we don't want to expose
 // them to library users.
@@ -291,12 +289,12 @@ macro_rules! libc_ewriteln {
 #[macro_export]
 macro_rules! libc_dbg {
     () => {
-        $crate::libc_eprintln!("[{}:{}]", $file!(), $line!())
+        $crate::libc_eprintln!("[{}:{}]", ::core::file!(), ::core::line!())
     };
     ($val:expr $(,)?) => {
         match $val {
             tmp => {
-                $crate::libc_eprintln!("[{}:{}] {} = {:#?}", file!(), line!(), stringify!($val), &tmp);
+                $crate::libc_eprintln!("[{}:{}] {} = {:#?}", ::core::file!(), ::core::line!(), ::core::stringify!($val), &tmp);
                 tmp
             }
         }


### PR DESCRIPTION
For os=none, wasm32-unknown-unknown, require the user to provide a write function