### PR TITLE
Use raw Windows API calls to support miri

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,6 +25,7 @@ jobs:
       run: cargo test --lib --verbose
     - name: Install miri
       if: matrix.job == 'miri'
+      shell: bash
       run: |
         rustup toolchain install nightly
         rustup component add --toolchain=nightly miri

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,27 +16,31 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
+        job: [test, miri]
     steps:
     - uses: actions/checkout@v3
     - name: Build
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --lib --verbose
+    - name: Install miri
+      if: matrix.job == 'miri'
+      run: |
+        rustup toolchain install nightly
+        rustup component add miri
+        echo CARGO_SUBCOMMAND='+nightly miri' >> $GITHUB_ENV
     - name: Run example with RUSTFLAGS=-nostartfiles (linux)
       if: matrix.os == 'ubuntu-latest'
       run: |
-        cargo rustc --example writeln -- -C link_args="-nostartfiles" --cfg nostartfiles
-        target/debug/examples/writeln
+        cargo ${CARGO_SUBCOMMAND:} run --example writeln -- -C link_args="-nostartfiles" --cfg nostartfiles
     - name: Run example with RUSTFLAGS=-nostartfiles (mac)
       if: matrix.os == 'macOS-latest'
       run: |
-        cargo rustc --example writeln -- -C link_args="-e __start -nostartfiles" --cfg nostartfiles
-        target/debug/examples/writeln
+        cargo ${CARGO_SUBCOMMAND:} run --example writeln -- -C link_args="-e __start -nostartfiles" --cfg nostartfiles
     - name: Run example with RUSTFLAGS=-nostartfiles (windows)
       if: matrix.os == 'windows-latest'
       shell: bash
       run: |
-        cargo rustc --example writeln -- \
+        cargo ${CARGO_SUBCOMMAND:} run --example writeln -- \
           --cfg nostartfiles \
           -C link-args="/ENTRY:_start /SUBSYSTEM:console /DEFAULTLIB:msvcrt /DEFAULTLIB:ucrt /DEFAULTLIB:vcruntime"
-        target/debug/examples/writeln

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,7 +27,7 @@ jobs:
       if: matrix.job == 'miri'
       run: |
         rustup toolchain install nightly
-        rustup component add miri
+        rustup component add --toolchain=nightly miri
         echo CARGO_SUBCOMMAND='+nightly miri' >> $GITHUB_ENV
     - name: Run example with RUSTFLAGS=-nostartfiles (linux)
       if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,15 +32,15 @@ jobs:
     - name: Run example with RUSTFLAGS=-nostartfiles (linux)
       if: matrix.os == 'ubuntu-latest'
       run: |
-        cargo ${CARGO_SUBCOMMAND:} run --example writeln -- -C link_args="-nostartfiles" --cfg nostartfiles
+        cargo ${CARGO_SUBCOMMAND:-} run --example writeln -- -C link_args="-nostartfiles" --cfg nostartfiles
     - name: Run example with RUSTFLAGS=-nostartfiles (mac)
       if: matrix.os == 'macOS-latest'
       run: |
-        cargo ${CARGO_SUBCOMMAND:} run --example writeln -- -C link_args="-e __start -nostartfiles" --cfg nostartfiles
+        cargo ${CARGO_SUBCOMMAND:-} run --example writeln -- -C link_args="-e __start -nostartfiles" --cfg nostartfiles
     - name: Run example with RUSTFLAGS=-nostartfiles (windows)
       if: matrix.os == 'windows-latest'
       shell: bash
       run: |
-        cargo ${CARGO_SUBCOMMAND:} run --example writeln -- \
+        cargo ${CARGO_SUBCOMMAND:-} run --example writeln -- \
           --cfg nostartfiles \
           -C link-args="/ENTRY:_start /SUBSYSTEM:console /DEFAULTLIB:msvcrt /DEFAULTLIB:ucrt /DEFAULTLIB:vcruntime"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libc-print"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libc-print"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Matt Mastracci <matthew@mastracci.com>"]
 edition = "2021"
 description = "println! and eprintln! macros on libc without stdlib"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,6 @@ readme = "README.md"
 name = "libc_print"
 
 [dependencies]
-
-[target.'cfg(not(windows))'.dependencies]
 libc = { version = "0.2.186", default-features = false }
 
 [lints.rust]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ description = "println! and eprintln! macros on libc without stdlib"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/mmastrac/rust-libc-print"
 readme = "README.md"
+categories = ["no-std", "logging", "embedded", "development-tools::debugging"]
 
 [lib]
 name = "libc_print"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ readme = "README.md"
 name = "libc_print"
 
 [dependencies]
+
+[target.'cfg(not(windows))'.dependencies]
 libc = { version = "0.2.186", default-features = false }
 
 [lints.rust]

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ For platforms with `write` in libc, this crate uses `libc::write`. For `unknown`
 and `none` OS targets, the user is required to provide a `write` function via
 the linker.
 
+This crate support `miri` on all platforms, though it may choose different code
+paths for compatibility reasons.
+
 ## Usage
 
 Exactly as you'd use `println!`, `eprintln!` and `dbg!`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,6 +118,7 @@ mod write {
     }
 }
 
+// Note: we may offer the lower-level WriteFile in the future.
 #[cfg(all(windows, miri))]
 mod write {
     use core::ffi::c_void;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,10 @@ pub fn __libc_println(handle: i32, msg: &str) -> core::fmt::Result {
     Ok(())
 }
 
-#[cfg(not(any(all(target_family = "wasm", target_os = "unknown"), target_os = "none")))]
+#[cfg(all(
+    not(windows),
+    not(any(all(target_family = "wasm", target_os = "unknown"), target_os = "none"))
+))]
 mod write {
     pub(crate) use libc::write;
 }
@@ -112,6 +115,81 @@ mod write {
     // The user is required to provide this
     unsafe extern "C" {
         pub(crate) fn write(fd: i32, buf: *const u8, nbyte: usize) -> isize;
+    }
+}
+
+#[cfg(windows)]
+mod write {
+    use core::{ffi::c_void, sync::atomic::AtomicPtr};
+
+    type BOOL = i32;
+    type DWORD = u32;
+    type HANDLE = *mut c_void;
+
+    const INVALID_HANDLE_VALUE: isize = -1;
+    const STD_OUTPUT_HANDLE: DWORD = (-11i32) as DWORD;
+    const STD_ERROR_HANDLE: DWORD = (-12i32) as DWORD;
+
+    unsafe extern "system" {
+        fn GetStdHandle(nStdHandle: DWORD) -> HANDLE;
+        fn WriteFile(
+            hFile: HANDLE,
+            lpBuffer: *const c_void,
+            nNumberOfBytesToWrite: DWORD,
+            lpNumberOfBytesWritten: *mut DWORD,
+            lpOverlapped: *mut c_void,
+        ) -> BOOL;
+    }
+
+    #[inline]
+    unsafe fn handle_from_fd(fd: i32) -> Option<HANDLE> {
+        use core::sync::atomic::{AtomicPtr, Ordering};
+                
+        static STD_OUTPUT: AtomicPtr<c_void> = AtomicPtr::new(INVALID_HANDLE_VALUE as _);
+        static STD_ERROR: AtomicPtr<c_void> = AtomicPtr::new(INVALID_HANDLE_VALUE as _);
+
+        let (std_handle, which) = match fd {
+            1 => (STD_OUTPUT_HANDLE, &STD_OUTPUT),
+            2 => (STD_ERROR_HANDLE, &STD_ERROR),
+            _ => return None,
+        };
+
+        let mut handle = which.load(Ordering::Relaxed);
+        if handle as isize == INVALID_HANDLE_VALUE {
+            handle = GetStdHandle(std_handle);
+            which.store(handle, Ordering::Relaxed);
+        }
+
+        if handle as isize == INVALID_HANDLE_VALUE {
+            None
+        } else {
+            Some(handle as HANDLE)
+        }
+    }
+
+    pub(crate) unsafe fn write(fd: i32, buf: *const u8, nbyte: usize) -> isize {
+        let h = match unsafe { handle_from_fd(fd) } {
+            Some(h) => h,
+            None => return -1,
+        };
+
+        let to_write: DWORD = match DWORD::try_from(nbyte) {
+            Ok(v) => v,
+            Err(_) => DWORD::MAX,
+        };
+
+        let mut written: DWORD = 0;
+        let ok = unsafe {
+            WriteFile(
+                h,
+                buf as *const c_void,
+                to_write,
+                &mut written,
+                core::ptr::null_mut(),
+            )
+        };
+
+        if ok == 0 { -1 } else { written as isize }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,7 @@ mod write {
     use core::ffi::c_void;
     use core::sync::atomic::{AtomicPtr, Ordering};
 
+    #[cfg(not(miri))]
     type BOOL = i32;
     type DWORD = u32;
     type ULONG = u32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ pub fn __libc_println(handle: i32, msg: &str) -> core::fmt::Result {
 }
 
 #[cfg(all(
-    not(windows),
+    not(all(windows, miri)),
     not(any(all(target_family = "wasm", target_os = "unknown"), target_os = "none"))
 ))]
 mod write {
@@ -118,7 +118,7 @@ mod write {
     }
 }
 
-#[cfg(windows)]
+#[cfg(all(windows, miri))]
 mod write {
     use core::ffi::c_void;
     use core::sync::atomic::{AtomicPtr, Ordering};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,9 +153,14 @@ mod write {
             _ => return None,
         };
 
+        // Races are OK - we will get the same value each time assuming nobody
+        // is calling SetStdHandle at the same time.
         let mut handle = which.load(Ordering::Relaxed);
         if handle as isize == INVALID_HANDLE_VALUE {
             handle = unsafe { GetStdHandle(std_handle) };
+            if handle.is_null() || handle as isize == INVALID_HANDLE_VALUE {
+                return None;
+            }
             which.store(handle, Ordering::Relaxed);
         }
 
@@ -188,7 +193,11 @@ mod write {
             )
         };
 
-        if ok == 0 { -1 } else { written as isize }
+        if ok == 0 {
+            -1
+        } else {
+            written as isize
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,14 +125,36 @@ mod write {
 
     type BOOL = i32;
     type DWORD = u32;
+    type ULONG = u32;
     type HANDLE = *mut c_void;
+    type NTSTATUS = i32;
 
     const INVALID_HANDLE_VALUE: isize = -1;
     const STD_OUTPUT_HANDLE: DWORD = (-11i32) as DWORD;
     const STD_ERROR_HANDLE: DWORD = (-12i32) as DWORD;
 
+    // https://learn.microsoft.com/windows-hardware/drivers/ddi/wdm/ns-wdm-_io_status_block
+    // The first field is a pointer-sized union; model it as `usize`.
+    #[cfg(miri)]
+    #[cfg(target_pointer_width = "64")]
+    #[repr(C)]
+    struct IO_STATUS_BLOCK {
+        status_or_ptr: usize,
+        information: usize,
+    }
+
+    #[cfg(miri)]
+    #[cfg(target_pointer_width = "32")]
+    #[repr(C)]
+    struct IO_STATUS_BLOCK {
+        status_or_ptr: u32,
+        information: u32,
+    }
+
     unsafe extern "system" {
         fn GetStdHandle(nStdHandle: DWORD) -> HANDLE;
+
+        #[cfg(not(miri))]
         fn WriteFile(
             hFile: HANDLE,
             lpBuffer: *const c_void,
@@ -140,39 +162,93 @@ mod write {
             lpNumberOfBytesWritten: *mut DWORD,
             lpOverlapped: *mut c_void,
         ) -> BOOL;
+
+        #[cfg(miri)]
+        fn NtWriteFile(
+            FileHandle: HANDLE,
+            Event: HANDLE,
+            ApcRoutine: *mut c_void,
+            ApcContext: *mut c_void,
+            IoStatusBlock: *mut IO_STATUS_BLOCK,
+            Buffer: *const c_void,
+            Length: ULONG,
+            ByteOffset: *mut c_void,
+            Key: *mut c_void,
+        ) -> NTSTATUS;
     }
 
     #[inline]
-    unsafe fn handle_from_fd(fd: i32) -> Option<HANDLE> {
+    fn cached_std_handle(fd: i32) -> Option<(DWORD, &'static AtomicPtr<c_void>)> {
         static STD_OUTPUT: AtomicPtr<c_void> = AtomicPtr::new(INVALID_HANDLE_VALUE as _);
         static STD_ERROR: AtomicPtr<c_void> = AtomicPtr::new(INVALID_HANDLE_VALUE as _);
 
-        let (std_handle, which) = match fd {
-            1 => (STD_OUTPUT_HANDLE, &STD_OUTPUT),
-            2 => (STD_ERROR_HANDLE, &STD_ERROR),
-            _ => return None,
-        };
+        match fd {
+            1 => Some((STD_OUTPUT_HANDLE, &STD_OUTPUT)),
+            2 => Some((STD_ERROR_HANDLE, &STD_ERROR)),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    fn handle_from_fd(fd: i32) -> Option<HANDLE> {
+        let (std_handle, which) = cached_std_handle(fd)?;
 
         // Races are OK - we will get the same value each time assuming nobody
         // is calling SetStdHandle at the same time.
         let mut handle = which.load(Ordering::Relaxed);
-        if handle as isize == INVALID_HANDLE_VALUE {
-            handle = unsafe { GetStdHandle(std_handle) };
+        if handle.is_null() || handle as isize == INVALID_HANDLE_VALUE {
+            handle = unsafe { GetStdHandle(std_handle) } as *mut c_void;
             if handle.is_null() || handle as isize == INVALID_HANDLE_VALUE {
                 return None;
             }
             which.store(handle, Ordering::Relaxed);
         }
 
-        if handle as isize == INVALID_HANDLE_VALUE {
-            None
+        Some(handle as HANDLE)
+    }
+
+    #[cfg(miri)]
+    pub(crate) unsafe fn write(fd: i32, buf: *const u8, nbyte: usize) -> isize {
+        let h = match handle_from_fd(fd) {
+            Some(h) => h,
+            None => return -1,
+        };
+
+        let len: ULONG = match ULONG::try_from(nbyte) {
+            Ok(v) => v,
+            Err(_) => ULONG::MAX,
+        };
+
+        let mut iosb = IO_STATUS_BLOCK {
+            status_or_ptr: 0,
+            information: 0,
+        };
+
+        let status = unsafe {
+            NtWriteFile(
+                h,
+                core::ptr::null_mut(),
+                core::ptr::null_mut(),
+                core::ptr::null_mut(),
+                &mut iosb,
+                buf as *const c_void,
+                len,
+                core::ptr::null_mut(),
+                core::ptr::null_mut(),
+            )
+        };
+
+        // NT_SUCCESS: status >= 0
+        if status < 0 {
+            -1
         } else {
-            Some(handle as HANDLE)
+            iosb.information as isize
         }
     }
 
+    #[cfg(not(miri))]
     pub(crate) unsafe fn write(fd: i32, buf: *const u8, nbyte: usize) -> isize {
-        let h = match unsafe { handle_from_fd(fd) } {
+        let h = match handle_from_fd(fd) {
             Some(h) => h,
             None => return -1,
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,8 @@ mod write {
 
 #[cfg(windows)]
 mod write {
-    use core::{ffi::c_void, sync::atomic::AtomicPtr};
+    use core::ffi::c_void;
+    use core::sync::atomic::{AtomicPtr, Ordering};
 
     type BOOL = i32;
     type DWORD = u32;
@@ -143,8 +144,6 @@ mod write {
 
     #[inline]
     unsafe fn handle_from_fd(fd: i32) -> Option<HANDLE> {
-        use core::sync::atomic::{AtomicPtr, Ordering};
-                
         static STD_OUTPUT: AtomicPtr<c_void> = AtomicPtr::new(INVALID_HANDLE_VALUE as _);
         static STD_ERROR: AtomicPtr<c_void> = AtomicPtr::new(INVALID_HANDLE_VALUE as _);
 
@@ -156,7 +155,7 @@ mod write {
 
         let mut handle = which.load(Ordering::Relaxed);
         if handle as isize == INVALID_HANDLE_VALUE {
-            handle = GetStdHandle(std_handle);
+            handle = unsafe { GetStdHandle(std_handle) };
             which.store(handle, Ordering::Relaxed);
         }
 


### PR DESCRIPTION
`miri` isn't happy with `libc-print` because it doesn't shim `write` at this time. We can switch to raw Windows API calls to work around this.